### PR TITLE
fix MySQLConnection & dependencies update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>fr.mrmicky</groupId>
             <artifactId>FastBoard</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.kaotich00</groupId>
     <artifactId>easyranking</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <packaging>jar</packaging>
 
     <name>Easyranking</name>
@@ -43,7 +43,7 @@
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <!--<outputDirectory>C:\Users\Simone\Desktop\Jatuldar\Server locale\plugins</outputDirectory>-->
-                            <outputDirectory>C:\Users\Simone\Desktop\Minecraft\Jatuldar\plugins</outputDirectory>
+                            <outputDirectory>C:\Users\Vin\Desktop\SERBEN\plugins</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <version>1.17.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>3.4.5</version>
+            <version>5.0.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/kaotich00/easyranking/storage/sql/hikari/MySQLConnectionFactory.java
+++ b/src/main/java/me/kaotich00/easyranking/storage/sql/hikari/MySQLConnectionFactory.java
@@ -12,7 +12,7 @@ public class MySQLConnectionFactory extends HikariConnectionFactory {
 
     @Override
     protected String getDrivers() {
-        return "com.mysql.jdbc.jdbc2.optional.MysqlDataSource";
+        return "com.mysql.cj.jdbc.MysqlDataSource";
     }
 
     @Override


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- fix MysqlDataSource class path name from com.mysql.jdbc.jdbc2.optional.MysqlDataSource to com.mysql.cj.jdbc.MysqlDataSource in Factory
- dependencies updated:
       ● spigot-api from 1.16.1 to 1.17.1;
       ● HikariCP from 3.4.5 to 5.0.0
       ● fastboard from 1.1.0 to 1.2.0 (it solves '/ er show' npe)

